### PR TITLE
RA-2020:Fixed auto update of translations from transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,9 +1,9 @@
 [main]
 host = https://www.transifex.com/
 
-[OpenMRS.mdr-tb-module]
+[o:openmrs:p:OpenMRS:r:mdr-tb-module]
+file_filter = api/src/main/resources/messages_<lang>.properties
 source_file = api/src/main/resources/messages.properties
 source_lang = en
-file_filter = api/src/main/resources/messages_<lang>.properties
-type = UNICODEPROPERTIES 
+type        = UNICODEPROPERTIES
 

--- a/.tx/config
+++ b/.tx/config
@@ -4,23 +4,6 @@ host = https://www.transifex.com/
 [OpenMRS.mdr-tb-module]
 source_file = api/src/main/resources/messages.properties
 source_lang = en
-trans.fr = api/src/main/resources/messages_fr.properties
-trans.ht = api/src/main/resources/messages_ht.properties
-trans.pt = api/src/main/resources/messages_pt.properties
-trans.de = api/src/main/resources/messages_de.properties
-trans.es = api/src/main/resources/messages_es.properties
-trans.fa = api/src/main/resources/messages_fa.properties
-trans.si = api/src/main/resources/messages_si.properties
-trans.hi = api/src/main/resources/messages_hi.properties
-trans.ar = api/src/main/resources/messages_ar.properties
-trans.pl = api/src/main/resources/messages_pl.properties
-trans.it = api/src/main/resources/messages_it.properties
-trans.el = api/src/main/resources/messages_el.properties
-trans.ru = api/src/main/resources/messages_ru.properties
-trans.lt = api/src/main/resources/messages_lt.properties
-trans.hy = api/src/main/resources/messages_hy.properties
-trans.te = api/src/main/resources/messages_te.properties
-trans.sw = api/src/main/resources/messages_sw.properties
-trans.ku = api/src/main/resources/messages_ku.properties
-trans.id_ID = api/src/main/resources/messages_id_ID.properties
+file_filter = api/src/main/resources/messages_<lang>.properties
+type = UNICODEPROPERTIES 
 


### PR DESCRIPTION
**Summary of changes:**
Upgraded my Transifex client.
Backed up previous configuration by running` tx migrate.`
Pulled down all message property translation files and updated the source on my local machine using `tx pull --all -f `command. The `-f` flag forced the update from the server even if the files were newer.
Committed the changes back to the repository.

**Work done on the issue:**
Completed the task described in the[ issue RA-2020 ](https://issues.openmrs.org/browse/RA-2020)on the OpenMRS issue tracker.
Upgraded Transifex client.
Backed up previous configuration with tx migrate.
Synchronized local translation files with the server by running` tx pull --all -f.`
Committed the changes to the repository.